### PR TITLE
Add support for setting a custom http agent

### DIFF
--- a/lib/regaliator.js
+++ b/lib/regaliator.js
@@ -77,6 +77,10 @@ function Regaliator(apiHost, apiKey, secret, version) {
   this.transactions = function (params) {
     return this.request.get('/transactions', params);
   };
+
+  this.setHttpAgent = function (httpAgent) {
+    this.request.httpAgent = httpAgent || null
+  }
 }
 
 module.exports = Regaliator;

--- a/lib/request.js
+++ b/lib/request.js
@@ -18,6 +18,7 @@ function Request(apiHost, apiKey, secret, version) {
   this.apiHost = apiHost;
   this.apiKey = apiKey;
   this.secret = secret;
+  this.httpAgent = null;
 
   let that = this;
 
@@ -105,6 +106,9 @@ function Request(apiHost, apiKey, secret, version) {
 
       options.method = method;
       options.headers = headers;
+      if (that.httpAgent) {
+        options.agent = that.httpAgent;
+      }
 
       let req = https.request(options, (res) => {
         let body = '';


### PR DESCRIPTION
This PR adds a new `setHttpAgent` method to the API that sets the [`options.agent`](https://nodejs.org/api/http.html#http_http_request_options_callback) for requests.

The name is inspired from a similar method in [`stripe-node`](https://github.com/stripe/stripe-node/blob/4e0da9c46c3f2bf4d136e76a5aa8ab88ac11c4ac/lib/stripe.js#L223) but I am open to changing it for a better name